### PR TITLE
Add plugin for slack

### DIFF
--- a/opi/plugins/slack.py
+++ b/opi/plugins/slack.py
@@ -1,0 +1,27 @@
+import opi
+from opi.plugins import BasePlugin
+import subprocess
+
+class Slack(BasePlugin):
+	main_query = "slack"
+	description = "Slack messenger"
+	queries = ('slack')
+
+	@classmethod
+	def run(cls, query):
+		if not opi.ask_yes_or_no("Do you want to install slack from the slack repository?", 'y'):
+			return
+
+		opi.add_repo(
+			filename = 'slack',
+			name = 'slack',
+			url = 'https://packagecloud.io/slacktechnologies/slack/fedora/21/$basearch',
+			gpgkey = 'https://packagecloud.io/slacktechnologies/slack/gpgkey'
+		)
+
+		# tell slack cron not to mess with our repos
+		subprocess.call(['sudo', 'rm', '-f', '/etc/default/slack'])
+		subprocess.call(['sudo', 'touch', '/etc/default/slack'])
+
+		subprocess.call(['sudo', 'zypper', 'in', 'slack'])
+		opi.ask_keep_repo('slack')


### PR DESCRIPTION
The `fedora/21` url for the repo is correct.
It seems that according to https://packagecloud.io/slacktechnologies/slack the slack guys only ever use that repo to publish RPMs.
They don't use other repos at all.

Fixes #25