### PR TITLE
Added gstreamer-plugins-good and -extra to codecs query

### DIFF
--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -82,6 +82,12 @@ def install_packman_packages(packages):
 ### ZYPP ###
 ############
 
+def install_packages(packages):
+    args = ['sudo', 'zypper', 'in']
+    args.extend(packages)
+    subprocess.call(args)
+
+
 def add_repo(filename, name, url, enabled=True, gpgcheck=True, gpgkey=None, repo_type='rpm-md', auto_import_key=False):
 	tf = tempfile.NamedTemporaryFile('w')
 	tf.file.write("[%s]\n" % filename)

--- a/opi/plugins/packman.py
+++ b/opi/plugins/packman.py
@@ -22,5 +22,5 @@ class PackmanCodecsPlugin(BasePlugin):
 			'vlc-codecs',
 		])
 		# Install other codecs
-		opi.install_packages(['gstreamer-plugins-good'])
-		opi.install_packages(['gstreamer-plugins-good-extra'])
+		opi.install_packages(['gstreamer-plugins-good',
+							  'gstreamer-plugins-good-extra'])

--- a/opi/plugins/packman.py
+++ b/opi/plugins/packman.py
@@ -21,3 +21,6 @@ class PackmanCodecsPlugin(BasePlugin):
 			'libavcodec-full',
 			'vlc-codecs',
 		])
+		# Install other codecs
+		opi.install_packages(['gstreamer-plugins-good'])
+		opi.install_packages(['gstreamer-plugins-good-extra'])


### PR DESCRIPTION
Hey there the initial impulse to do this minor change was me as I was messing around with codecs and removed codec packages one by one to reproduce an issue some one else had with his openSUSE install to better guide him to which package he might had missing.

Anyway, after rerunning `opi codecs` to get everything back to normal I did not noticed that gstreamer-plugins-good and [...]-extra was missing and some media on my system failed to play.

Since I did not wanted to create a whole new plugin for this I just added these two packages to the packman plugin and extended the `opi/__init__.py` with a function to allow for just installing packages without the whole install_binary() stuff around it since I felt like this only being a minor change and did not wanted to create too much bloat around this.
Also because packman does not offer [...]-good and [...]-good-extra

If this does not conform with the current state of the project feel free to decline this pull request :)