### PR TITLE
Create repos with 644 insted of 600 permissions

### DIFF
--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -95,6 +95,7 @@ def add_repo(filename, name, url, enabled=True, gpgcheck=True, gpgkey=None, repo
 		tf.file.write("gpgkey=%s\n" % gpgkey)
 	tf.file.flush()
 	subprocess.call(['sudo', 'cp', tf.name, '/etc/zypp/repos.d/%s.repo' % filename])
+	subprocess.call(['sudo', 'chmod', '644', '/etc/zypp/repos.d/%s.repo' % filename])
 	tf.file.close()
 	refresh_cmd = ['sudo', 'zypper']
 	if auto_import_key:


### PR DESCRIPTION
Otherwise `zypper lr` won't work for that repos if called by normal user.