### PR TITLE
Fixed program crash on illegal input when selecting number

### DIFF
--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -291,13 +291,14 @@ def ask_yes_or_no(question, default_answer):
 	return answer.strip().lower() == 'y'
 
 def ask_number(min_num, max_num, question="Choose a number (0 to quit):"):
-	num = int(input(question + ' ').strip() or '0')
+	input_string = input(question + ' ').strip() or '0'
+	num = int(input_string) if input_string.isdecimal() else -1
 	if num == 0:
 		sys.exit()
 	elif num >= min_num and num <= max_num:
 		return num
 	else:
-		return ask_number(question, min_num, max_num)
+		return ask_number(min_num, max_num, question)
 
 def ask_keep_repo(repo):
 	if not ask_yes_or_no('Do you want to keep the repo "%s"?' % repo, 'y'):


### PR DESCRIPTION
When the program asking for number if the input is out of bounds then it crashes with `TypeError: unsupported operand type(s) for +: 'int' and 'str'`, fixed the typo causing it.
If enter non digit char then crash with `ValueError: invalid literal for int() with base 10`, added checks to make sure input is digit number