### PR TITLE
Filter the search results by keyword

### DIFF
--- a/bin/opi
+++ b/bin/opi
@@ -33,6 +33,9 @@ try:
 	)
 	ap.add_argument('-v', '--version', action='version', version=('opi version ' +  __version__))
 	ap.add_argument('-r', '--reversed-output', action='store_true', help='print the search results in reverse')
+	ap.add_argument('keyword', nargs='?', type=str,
+		help='filter the search results with this keyword', default=""
+	)
 
 	args = ap.parse_args()
 
@@ -52,11 +55,11 @@ try:
 		sys.exit()
 	binary_names = opi.get_binary_names(binaries)
 
-	# Print package name options
-	opi.print_package_names(binary_names, reverse=args.reversed_output)
+	# Print package name options, returns the package numbers that were printed and can be selected by user
+	selectable_nums = opi.print_package_names(binary_names, args.keyword, reverse=args.reversed_output)
 
 	# Select a package name option
-	selected_name_num = opi.ask_number(1, len(binary_names))
+	selected_name_num = opi.ask_number(selectable_nums)
 	selected_name = binary_names[selected_name_num-1]
 	print("You have selected package name: %s" % selected_name)
 	binary_options = opi.get_binaries_by_name(selected_name, binaries)
@@ -65,7 +68,7 @@ try:
 	opi.print_binary_options(binary_options)
 
 	# Select a binary package option
-	selected_binary_num = opi.ask_number(1, len(binary_options))
+	selected_binary_num = opi.ask_number(selectable_nums)
 	selected_binary = binary_options[selected_binary_num-1]
 	print("You have selected binary package: ", end='')
 	opi.print_binary_option(selected_binary)

--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -290,15 +290,15 @@ def ask_yes_or_no(question, default_answer):
 	answer = input(q) or default_answer
 	return answer.strip().lower() == 'y'
 
-def ask_number(min_num, max_num, question="Choose a number (0 to quit):"):
+def ask_number(selectable_nums, question="Choose a number (0 to quit):"):
 	input_string = input(question + ' ').strip() or '0'
 	num = int(input_string) if input_string.isdecimal() else -1
 	if num == 0:
 		sys.exit()
-	elif num >= min_num and num <= max_num:
+	elif num in selectable_nums:
 		return num
 	else:
-		return ask_number(min_num, max_num, question)
+		return ask_number(selectable_nums, question)
 
 def ask_keep_repo(repo):
 	if not ask_yes_or_no('Do you want to keep the repo "%s"?' % repo, 'y'):
@@ -307,16 +307,20 @@ def ask_keep_repo(repo):
 		if get_backend() == BackendConstants.dnf:
 			subprocess.call(['sudo', 'rm', '/etc/zypp/repos.d/' + repo + '.repo'])
 
-def print_package_names(package_names, reverse=False):
+def print_package_names(package_names, keyword, reverse=False):
 	package_list = []
+	selectable_nums = []
 	i = 1
 	for package_name in package_names:
-		package_list.append("%2d. %s" % (i, package_name))
+		if keyword == "" or (keyword != "" and keyword in package_name):
+			package_list.append("%2d. %s" % (i, package_name))
+			selectable_nums.append(i)
 		i += 1
 	if reverse:
 		package_list.reverse()
 	for e in package_list:
 		print(e)
+	return selectable_nums
 
 def print_binary_options(binaries):
 	i = 1


### PR DESCRIPTION
#56 asked for filter by keyword to make using opi easier in tty.
For example `opi rtl dvb` will show all rtl packages that have the "dvb" keyword.
Also changed the implementation of `ask_number()` to make sure the user cannot select any packages that were not printed.