### PR TITLE
Update .NET SDK to 6.0

### DIFF
--- a/opi/plugins/dotnet.py
+++ b/opi/plugins/dotnet.py
@@ -19,5 +19,5 @@ class MSDotnet(BasePlugin):
 			gpgkey = 'https://packages.microsoft.com/keys/microsoft.asc'
 		)
 
-		opi.install_packages(['dotnet-sdk-5.0'])
+		opi.install_packages(['dotnet-sdk-6.0'])
 		opi.ask_keep_repo('dotnet')


### PR DESCRIPTION
Currently opi installs .NET 5 which will go end-of-life on the 8th May 2022.