### PR TITLE
Check if user query is a substring of the possible queries

### DIFF
--- a/opi/plugins/__init__.py
+++ b/opi/plugins/__init__.py
@@ -9,8 +9,11 @@ class BasePlugin(object):
 	queries = ()
 
 	@classmethod
-	def matches(cls, query):
-		return query in cls.queries
+	def matches(cls, user_query):
+		for query in cls.queries:
+			if query.find(user_query) != -1:
+				return True
+		return False
 
 	@classmethod
 	def run(cls, query):


### PR DESCRIPTION
Hey!

I'm using openSUSE again and I tried to install Brave, but instead of ```opi brave``` I used ```opi brave-browser``` because of the package name in other distros. I think it would be interesting to check if the user query is a substring of any of the query options.

Have a look at my changes.
Thanks!