### PR TITLE
Update README plugins list & unify plugin descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Also these queries can be used to install packages from various other vendors:
   chrome            Google Chrome web browser
   codecs            Media Codecs from Packman and official repo
   dotnet            Microsoft .NET
+  jami              Jami p2p messenger
   megasync          Mega Desktop App
-  msedge-beta       Microsoft Edge Beta
-  msedge-dev        Microsoft Edge Dev
-  msteams           Microsoft Teams
+  msedge            Microsoft Edge
   plex              Plex Media Server
+  resilio-sync      Resilio Sync decentralized file synchronization between devices using the bittorrent protocol
   skype             Microsoft Skype
   slack             Slack messenger
   sublime           Editor for code, markup and prose
@@ -120,7 +120,7 @@ Also these queries can be used to install packages from various other vendors:
   vivaldi           Vivaldi web browser
   vscode            Microsoft Visual Studio Code
   vscodium          Visual Studio Codium
-  yandex-disk       Yandex.Disk cloud storage client
   yandex-browser    Yandex web browser
+  yandex-disk       Yandex.Disk cloud storage client
   zoom              Zoom Video Conference
 ```

--- a/opi/plugins/jami.py
+++ b/opi/plugins/jami.py
@@ -3,7 +3,7 @@ from opi.plugins import BasePlugin
 
 class Jami(BasePlugin):
 	main_query = "jami"
-	description = "Jami p2p messenger."
+	description = "Jami p2p messenger"
 	queries = [main_query, 'jami-qt', 'jami-gnome', 'jami-daemon']
 
 	@classmethod

--- a/opi/plugins/resilio-sync.py
+++ b/opi/plugins/resilio-sync.py
@@ -4,7 +4,7 @@ import subprocess
 
 class ResilioSync(BasePlugin):
 	main_query = "resilio-sync"
-	description = "Resilio Sync decentralized file synchronization between devices using the bittorrent protocol."
+	description = "Resilio Sync decentralized file synchronization between devices using the bittorrent protocol"
 	queries = ['resilio-sync', 'resilio', 'rslsync']
 
 	@classmethod


### PR DESCRIPTION
Updates the plugins list in the README.
Removes *MS Teams* from the list because of commit [16fcd05](https://github.com/openSUSE/opi/commit/16fcd05e25343bfc89e5b12550e5242c76969538).

Unifies the descriptions of plugins by removing dots (`.`).