### PR TITLE
Update repo URL for MEGASync

### DIFF
--- a/opi/plugins/megasync.py
+++ b/opi/plugins/megasync.py
@@ -16,8 +16,8 @@ class MEGAsync(BasePlugin):
 		opi.add_repo(
 			filename = 'megasync',
 			name = 'MEGAsync',
-			url = 'https://mega.nz/linux/MEGAsync/openSUSE_Tumbleweed/',
-			gpgkey = 'https://mega.nz/linux/MEGAsync/openSUSE_Tumbleweed/repodata/repomd.xml.key'
+			url = 'https://mega.nz/linux/repo/openSUSE_Tumbleweed/',
+			gpgkey = 'https://mega.nz/linux/repo/openSUSE_Tumbleweed/repodata/repomd.xml.key'
 		)
 
 		packages = ['megasync']


### PR DESCRIPTION
Somehow mega switched their repo to a new URL (can be verified [here](https://mega.io/desktop). The old URL is still accessible, but the packages there are outdated and give error during installation.