### PR TITLE
chore: update multi_install description

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ positional arguments:
                  for both at the openSUSE Build Service and Packman.
                  If multiple query arguments are provided only results
                  matching all of them are returned.
+                 Please use the -m option if you want to use the query
+                 arguments as individual package queries.
 
 options:
   -h, --help     show this help message and exit
   -v, --version  show program's version number and exit
   -n             run in non interactive mode
   -P             don't run any plugins - only search repos, OBS and Packman
-  -m             run installation process individually for each query arg
+  -m             use query args as space separated package queries
 
 Also these queries (provided by plugins) can be used to install packages from various other vendors:
   anydesk           AnyDesk remote access

--- a/bin/opi
+++ b/bin/opi
@@ -54,11 +54,12 @@ def setup_argparser(plugin_manager):
 	ap.add_argument('query', nargs='*', type=str, help=textwrap.dedent('''\
 		can be any package name or part of it and will be searched for both at the openSUSE Build Service and Packman.
 		If multiple query arguments are provided only results matching all of them are returned.
+		Please use the -m option if you want to use the query arguments as individual package queries.
 	'''))
 	ap.add_argument('-v', '--version', action='version', version=f'opi version {__version__}')
 	ap.add_argument('-n', dest='non_interactive', action='store_true', help='run in non interactive mode')
 	ap.add_argument('-P', dest='no_plugins', action='store_true', help="don't run any plugins - only search repos, OBS and Packman")
-	ap.add_argument('-m', dest='multi_package', action='store_true', help='run installation process individually for each query arg')
+	ap.add_argument('-m', dest='multi_install', action='store_true', help='use query args as space separated package queries')
 
 	return ap
 
@@ -132,15 +133,15 @@ if __name__ == '__main__':
 		if not args.no_plugins:
 			# Iterate over queries, copy list as modifying it from within the loop
 			for query in list(args.query):
-				# Try to find a matching plugin for the query (and run it); runs just first query if not in multi_package mode
+				# Try to find a matching plugin for the query (and run it); runs just first query if not in multi_install mode
 				if pm.run(query):
 					# After plugin successfully ran, remove from queries to not try again in repo search
 					args.query.remove(query)
-					if not args.multi_package:
+					if not args.multi_install:
 						sys.exit()
 
 		# Search repos
-		if not args.multi_package:
+		if not args.multi_install:
 			repo_query(args.query)
 		else:
 			for query in args.query:

--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -171,7 +171,7 @@ def search_local_repos(package):
 	except subprocess.CalledProcessError as e:
 		if e.returncode != 104:
 			# 104 ZYPPER_EXIT_INF_CAP_NOT_FOUND is returned if there are no results
-			raise
+			raise # TODO: don't exit program, use exception that will be handled in repo_query except block
 
 	repos_by_name = {expand_releasever(repo['name']): repo for repo in get_repos()}
 	local_installables = []


### PR DESCRIPTION
Rewrite description for `-m` option: https://github.com/openSUSE/opi/pull/157#issuecomment-1763434796

(Not sure how to do the other part of the request) 

---

Rename `multi_package` to `multi_install` as the name is not excluding plugins.

---

Mark possible program exit with `TODO`. Might unexpectedly cancel multi-install process?
I could add `subprocess.CalledProcessError` to the `repo_query` except block.
Alternatively, the error could be logged right there.

What do you think?