### PR TITLE
Allow selecting mirror 1st time when adding packman repo

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -20,7 +20,7 @@ sed -i -e "s/^\(Version: *\)[^ ]*$/\1${version}/" opi.spec
 osc vc -m "Version ${version}\n${changes}"
 vi opi.changes
 osc rm --force opi-*.tar.gz
-osc service dr
+osc service run
 osc add opi-*.tar.gz
 osc st
 osc diff|bat

--- a/test/01_install_from_packman.py
+++ b/test/01_install_from_packman.py
@@ -14,8 +14,11 @@ c.sendline('1')
 c.expect('1. .*Packman Essentials', timeout=10)
 c.sendline('1')
 
-c.expect('Do you want to reject the key', timeout=10)
-c.sendline('t')
+c.expect('Pick a mirror near your location', timeout=10)
+c.sendline('2')
+
+c.expect('Import package signing key', timeout=10)
+c.sendline('y')
 
 c.expect('Overall download size', timeout=60)
 c.expect('Continue', timeout=60)


### PR DESCRIPTION
This will look something like this:
```
You have selected package: Packman Essentials ? | 3.5 | x86_64
Adding packman repo
1. ftp.fau.de                 - University of Erlangen, Germany  -  1h sync
2. ftp.halifax.rwth-aachen.de - University of Aachen, Germany    -  1h sync
3. ftp.gwdg.de                - University of Göttingen, Germany -  4h sync
4. mirror.karneval.cz         - TES Media, Czech Republic        -  1h sync
5. mirrors.aliyun.com         - Alibaba Cloud, China             - 24h sync
Pick a mirror near your location (0 to quit): 2
Import package signing key 'PackMan Project (signing key) <packman@links2linux.de>' (Y/n) y
```