### PR TITLE
Add config option to reverse option order

### DIFF
--- a/opi.default.cfg
+++ b/opi.default.cfg
@@ -2,3 +2,4 @@
 backend = zypp
 use_releasever_var = true
 new_repo_auto_refresh = true
+list_in_reverse = false

--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -646,6 +646,8 @@ def ask_for_option(options, question='Pick a number (0 to quit):', option_filter
 				numbered_option = ' ' * len(number) + numbered_option[terminal_width:]
 		numbered_options.append(numbered_option)
 		i += 1
+	if config.get_key_from_config('list_in_reverse'):
+		numbered_options.reverse()
 	text = '\n'.join(numbered_options)
 	if global_state.arg_non_interactive:
 		input_string = '1' # default to first option in the list
@@ -655,7 +657,7 @@ def ask_for_option(options, question='Pick a number (0 to quit):', option_filter
 		print(text)
 		input_string = input(question + ' ')
 	else:
-		input_string = pager.ask_number_with_pager(text, question)
+		input_string = pager.ask_number_with_pager(text, question, start_at_bottom=config.get_key_from_config('list_in_reverse'))
 
 	input_string = input_string.strip() or '0'
 	num = int(input_string) if input_string.isdecimal() else -1

--- a/opi/config/__init__.py
+++ b/opi/config/__init__.py
@@ -5,6 +5,7 @@ default_config = {
 	'backend': 'zypp',
 	'use_releasever_var': True,
 	'new_repo_auto_refresh': True,
+	'list_in_reverse': False,
 }
 
 class ConfigError(Exception):
@@ -24,5 +25,6 @@ def get_key_from_config(key: str):
 				'backend': ocfg.get('backend'),
 				'use_releasever_var': ocfg.getboolean('use_releasever_var'),
 				'new_repo_auto_refresh': ocfg.getboolean('new_repo_auto_refresh'),
+				'list_in_reverse': ocfg.getboolean('list_in_reverse'),
 			})
 	return config_cache[key]

--- a/opi/pager.py
+++ b/opi/pager.py
@@ -2,7 +2,7 @@ import sys
 
 import curses
 
-def ask_number_with_pager(text, question='Pick a number (0 to quit):'):
+def ask_number_with_pager(text, question='Pick a number (0 to quit):', start_at_bottom=False):
 	try:
 		stdscr = curses.initscr()
 		curses.noecho()
@@ -12,7 +12,7 @@ def ask_number_with_pager(text, question='Pick a number (0 to quit):'):
 		max_top_line = text_len_lines - (curses.LINES - 2)
 		scrollarea = curses.newpad(text_len_lines, curses.COLS)
 		scrollarea.addstr(0, 0, text)
-		scrollarea_topline_ptr = 0
+		scrollarea_topline_ptr = max_top_line if start_at_bottom else 0
 		def ensure_scrollarea_bounds(scrollarea_topline_ptr):
 			scrollarea_topline_ptr = max(scrollarea_topline_ptr, 0)
 			scrollarea_topline_ptr = min(scrollarea_topline_ptr, max_top_line)


### PR DESCRIPTION
Fixes #175

![1](https://github.com/openSUSE/opi/assets/725608/e6f9988e-53bc-4b90-99e1-57444232b18b)
The pager will start at the bottom position in this mode.

![2](https://github.com/openSUSE/opi/assets/725608/426f79d2-e64a-481f-bc96-27dcc814f7f8)
![3](https://github.com/openSUSE/opi/assets/725608/63005933-244e-4500-8d9d-0d77ea728565)
