### PR TITLE
poc - add groups eg. for 3d-party plugins

### DIFF
--- a/bin/opi
+++ b/bin/opi
@@ -35,6 +35,12 @@ class PreserveWhiteSpaceWrapRawTextHelpFormatter(argparse.RawTextHelpFormatter):
 
 
 def setup_argparser(plugin_manager):
+	extras = plugin_manager.get_plugin_string(' ' * 2, 'extras')
+	if extras:
+		extras = textwrap.dedent('''\
+			\nThese queries are provided by plugins that are not part of the opi package:
+		''') + extras
+
 	ap = argparse.ArgumentParser(
 		formatter_class=PreserveWhiteSpaceWrapRawTextHelpFormatter,
 		description=textwrap.dedent('''\
@@ -49,7 +55,7 @@ def setup_argparser(plugin_manager):
 		'''),
 		epilog=textwrap.dedent('''\
 			Also these queries (provided by plugins) can be used to install packages from various other vendors:
-		''') + plugin_manager.get_plugin_string(' ' * 2))
+		''') + plugin_manager.get_plugin_string(' ' * 2) + extras)
 
 	ap.add_argument('query', nargs='*', type=str, help=textwrap.dedent('''\
 		can be any package name or part of it and will be searched for both at the openSUSE Build Service and Packman.

--- a/opi/plugins/__init__.py
+++ b/opi/plugins/__init__.py
@@ -7,6 +7,7 @@ class BasePlugin:
 	main_query = ''
 	description = ''
 	queries = []
+	group = ''
 
 	@classmethod
 	def matches(cls, query):
@@ -38,9 +39,11 @@ class PluginManager:
 					pass
 				return True
 
-	def get_plugin_string(self, indent=''):
+	def get_plugin_string(self, indent='', group=''):
 		plugins = ''
 		for plugin in self.plugins:
+			if group != 'all' and plugin.group != group:
+				continue
 			description = plugin.description.replace('\n', '\n' + (' ' * 16) + '  ')
 			plugins += f'{indent}{plugin.main_query:16}  {description}\n'
 		return plugins

--- a/opi/plugins/netbeans.py
+++ b/opi/plugins/netbeans.py
@@ -1,0 +1,17 @@
+import opi
+from opi.plugins import BasePlugin
+from opi import github
+
+class NetBeans(BasePlugin):
+	main_query = 'netbeans'
+	description = 'Development environment, tooling platform and application framework'
+	queries = ['netbeans', 'NetBeans']
+	group = 'extras'
+
+	@classmethod
+	def run(cls, query):
+		arch = opi.get_cpu_arch()
+		github.install_rpm_release('Friends-of-Apache-NetBeans', 'netbeans-installers',
+			filters=[lambda a: a['name'].endswith(f'{arch}.rpm')],
+			allow_unsigned=True # no key available
+		)


### PR DESCRIPTION
With the plugins, opi offers the option of using (almost) any source.
But there are cases where certain sources, for whatever reason, cannot or should not be included in the official opi package.
However, such plugins could be offered as a separate package (or simply as an independent file) and used in opi.
This proof-of-concept is intended to demonstrate this possibility and lists corresponding plugins as “3rd-party”, if available.
I leave this PR as a draft - maybe someone can do something with the idea and use it later for a corresponding extension.

Example output:
```
$ opi
usage: opi [-h] [-v] [-n] [-P] [-m] [query ...]

openSUSE Package Installer
==========================

Search and install almost all packages available for openSUSE and SLE:
  1. openSUSE Build Service
  2. Packman
  3. Popular packages for various vendors

positional arguments:
  query          can be any package name or part of it and will be searched for both at the openSUSE Build Service and Packman.
                 If multiple query arguments are provided only results matching all of them are returned.
                 Please use the -m option if you want to use the query arguments as individual package queries.

options:
  -h, --help     show this help message and exit
  -v, --version  show program's version number and exit
  -n             run in non interactive mode
  -P             don't run any plugins - only search repos, OBS and Packman
  -m             use query args as space separated package queries

Also these queries (provided by plugins) can be used to install packages from various other vendors:
  anydesk           AnyDesk remote access
  atom              Atom Text Editor
  brave             Brave web browser
  chrome            Google Chrome web browser
  codecs            Media Codecs from Packman and official repo
  collabora         Collabora desktop office
  dotnet            Microsoft .NET framework
  freeoffice        Office suite from SoftMaker (See OSS alternative libreoffice)
  jami              Jami p2p messenger
  libation          Tool for managing audible audiobooks
  maptool           Virtual Tabletop for playing roleplaying games
  megasync          Mega Desktop App
  msedge            Microsoft Edge web browser
  mullvad-browser   Mullvad web browser
  ocenaudio         Audio Editor
  orcaslicer        Slicer and controller for Bambu and other 3D printers
  plex              Plex Media Server (See OSS alternative jellyfin)
  resilio-sync      Decentralized file sync between devices using bittorrent protocol (See OSS alternative syncthing)
  skype             Microsoft Skype
  slack             Slack messenger
  spotify           Listen to music for a monthly fee
  sublime           Editor for code, markup and prose
  teams-for-linux   Unofficial Microsoft Teams for Linux client
  teamviewer        TeamViewer remote access
  vagrant           Tool for building and distributing development environments
  vivaldi           Vivaldi web browser
  vscode            Microsoft Visual Studio Code
  vscodium          Visual Studio Codium
  yandex-browser    Yandex web browser
  yandex-disk       Yandex.Disk cloud storage client
  zoom              Zoom Video Conference

These queries are provided by plugins that are not part of the opi package:
  netbeans          Development environment, tooling platform and application framework
```
