### PR TITLE
Fix version check in add_openh264_repo function

### DIFF
--- a/opi/__init__.py
+++ b/opi/__init__.py
@@ -149,7 +149,8 @@ def add_openh264_repo(dup=False):
 	project = project.replace('-Slowroll', '')
 	project = project.replace('openSUSE MicroOS', 'openSUSE Tumbleweed')
 	project = project.replace('openSUSE Leap Micro', 'openSUSE Leap')
-	if int(float(get_os_release()['VERSION'])) == 16:
+	version = get_os_release().get('VERSION')
+	if version is not None and int(float(version)) == 16:
 		project = project.replace('openSUSE Leap', 'openSUSE Leap 16')
 	project = project.replace(':', '_').replace(' ', '_')
 


### PR DESCRIPTION
Addresses #208.

The original code did not check whether the version was missing, which led to evident doom for users running Tumbleweed (which have no `VERSION`).

I have added a small checker loop to address this.